### PR TITLE
chore: deprecate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 # terraform-spacelift-policies
 
+## ⚠️ ARCHIVED - IMPORTANT: Module Deprecated
+
+**This module is no longer maintained.** We recommend using the [`spacelift_policy`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/policy) resource directly instead.
+
+**Why?** We realized this module was such a thin wrapper around the Terraform/OpenTofu resource that for simplicity, better clarity with less abstraction, the same can be accomplished by using the resource directly in your modules.
+
+---
+
 [![Release][release-badge]][latest-release]
 
 💡 Learn more about Masterpoint [below](#who-we-are-𐦂𖨆𐀪𖠋).


### PR DESCRIPTION
Internal conversation here: https://masterpoint.slack.com/archives/C0AU6U1GCKW/p1779201341667329

We are deprecating this module because this is just a wrapper that provides little value and serves simply as a wrapper and the code is better maintained in the root module level directly.